### PR TITLE
Add cmake flags for Apple-clang case to cover C/C++ and RELEASE/REWITHDEBINFO builds

### DIFF
--- a/var/spack/repos/builtin/packages/odc/package.py
+++ b/var/spack/repos/builtin/packages/odc/package.py
@@ -37,4 +37,7 @@ class Odc(CMakePackage):
         # https://github.com/JCSDA/spack-stack/issues/585
         if self.spec.satisfies("%apple-clang@14.0.3"):
             args.append(self.define("CMAKE_C_FLAGS_RELEASE", "-O1"))
+            args.append(self.define("CMAKE_CXX_FLAGS_RELEASE", "-O1"))
+            args.append(self.define("CMAKE_C_FLAGS_RELWITHDEBINFO", "-O1"))
+            args.append(self.define("CMAKE_CXX_FLAGS_RELWITHDEBINFO", "-O1"))
         return args


### PR DESCRIPTION
This PR adds extra CMAKE defines to cover the `-O1` workaround for apple-clang@14.0.3 builds.